### PR TITLE
Correctly detect tmp directory on more OS

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -53,11 +53,10 @@ class IntegrationSpec < MiniTest::Spec
 
         describe 'on failure' do
           it 'presents all executed commands with adds additional errors' do
-            assert_stdout /#{cross_mark} Done something great \| Executed `this_wont_work` in `\/tmp\/.*`, No such file or directory - this_wont_work/ do
+            assert_stdout /#{cross_mark} Done something great \| Executed `this_wont_work` in `.*`, No such file or directory - this_wont_work/ do
               exec("#{duty} test fail")
             end
 
- 
             assert_stdout /#{check_mark} This was even greater\s{1}/ do
               exec("#{duty} test fail")
             end


### PR DESCRIPTION
The former detection enforced the path of the temporary directory to include a "tmp" segment. At least for OSX this isn't true.

Example on OS X:

```
/private/var/folders/w_/lq9921dn2p31vwjmflwgbjy80000gn/T/d20151117-10948-z7n55k
```

w/o this fix the integration test fails:

```
Expected 
/✕ Done something great \| Executed `this_wont_work` in `.*s`, No such file or directory - this_wont_work/ 
to match 
"What just happend:\n\n✕ Done something great | Executed `this_wont_work` in `/private/var/folders/w_/lq9921dn2p31vwjmflwgbjy80000gn/T/d20151117-10948-z7n55k`, No such file or directory - this_wont_work\n✓ This was even greater\n".
```
